### PR TITLE
Update to defend against CVE-2016-4658 and CVE-2017-5946

### DIFF
--- a/docx.gemspec
+++ b/docx.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/chrahunt/docx'
   s.files       = Dir["README.md", "LICENSE.md", "lib/**/*.rb"]
 
-  s.add_dependency 'nokogiri', '~> 1.5'
-  s.add_dependency 'rubyzip',  '~> 1.1.6'
+  s.add_dependency 'nokogiri', '~> 1.7.1'
+  s.add_dependency 'rubyzip',  '~> 1.2.1'
 
   s.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
Bumped required versions of nokogiri ([CVE-2016-4658](https://github.com/sparklemotion/nokogiri/issues/1615)) and rubyzip ([CVE-2017-5946](//github.com/rubyzip/rubyzip/issues/315)).