### PR TITLE
Update to defend against CVE-2016-4658, CVE-2017-5946 and CVE-2017-9050

### DIFF
--- a/docx.gemspec
+++ b/docx.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/chrahunt/docx'
   s.files       = Dir["README.md", "LICENSE.md", "lib/**/*.rb"]
 
-  s.add_dependency 'nokogiri', '~> 1.5'
-  s.add_dependency 'rubyzip',  '~> 1.1.6'
+  s.add_dependency 'nokogiri', '~> 1.7.1'
+  s.add_dependency 'rubyzip',  '~> 1.2.1'
 
   s.add_development_dependency 'rspec'
 end

--- a/docx.gemspec
+++ b/docx.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/chrahunt/docx'
   s.files       = Dir["README.md", "LICENSE.md", "lib/**/*.rb"]
 
-  s.add_dependency 'nokogiri', '~> 1.7.1'
+  s.add_dependency 'nokogiri', '~> 1.8.1'
   s.add_dependency 'rubyzip',  '~> 1.2.1'
 
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
Bumped required versions of nokogiri ([CVE-2016-4658](https://github.com/sparklemotion/nokogiri/issues/1615) then [CVE-2017-9050](https://github.com/sparklemotion/nokogiri/issues/1673)) and rubyzip ([CVE-2017-5946](//github.com/rubyzip/rubyzip/issues/315)).

Test run:

```
$ rspec
...........................................

Finished in 4.19 seconds (files took 0.45862 seconds to load)
43 examples, 0 failures
```